### PR TITLE
add description to avoid opam warning

### DIFF
--- a/base58.opam
+++ b/base58.opam
@@ -5,6 +5,7 @@ maintainer: "Vincent Bernardoff <vb@luminar.eu.org>"
 authors: ["Vincent Bernardoff <vb@luminar.eu.org>"]
 homepage: "https://github.com/vbmithr/bs_api"
 doc: "https://vbmithr.github.io/ocaml-base58/doc"
+description: "Base58 library for Tezos"
 license: "ISC"
 dev-repo: "https://github.com/vbmithr/ocaml-base58.git"
 bug-reports: "https://github.com/vbmithr/ocaml-base58/issues"


### PR DESCRIPTION
Opam says "[WARNING] Failed checks on base58 package definition from source at
          git+https://github.com/vbmithr/ocaml-base58.git#b7d41eb3bca54fe5c392a2b2110659a13fb4b871:
    error 57: Synopsis and description must not be both empty"